### PR TITLE
fix: repo name in netlify cms config

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,5 +1,6 @@
 backend:
-  name: test-repo
+  name: github
+  repo: jdow79159/culture-portal
 media_folder: static/assets
 public_folder: /assets
 collections:


### PR DESCRIPTION
fix: repo name in netlify cms config